### PR TITLE
#60: 修复支付宝 PC 二维码页面跳转问题

### DIFF
--- a/src/agreement.js
+++ b/src/agreement.js
@@ -58,11 +58,13 @@ module.exports = {
 
     if (agreementObj.channel.substring(0, 6) === 'alipay') {
       var url = new URL(urlToOpen);
-      urlToOpen = 'http://d.alipay.com/i/index.htm?iframeSrc='
-        + encodeURIComponent('alipays://platformapi/startapp?appId=60000157'
-          +'&appClearTop=false&startMultApp=YES&sign_params='
-          + encodeURIComponent(url.search.substring(1))
-        );
+      if (agreementObj.channel !== 'alipay_pc_direct') {
+        urlToOpen = 'http://d.alipay.com/i/index.htm?iframeSrc='
+          + encodeURIComponent('alipays://platformapi/startapp?appId=60000157'
+            +'&appClearTop=false&startMultApp=YES&sign_params='
+            + encodeURIComponent(url.search.substring(1))
+          );
+      }
     }
 
     setTimeout(function() {


### PR DESCRIPTION
没有找到合适的支付宝中间页，目前按 channel 来判断，支付宝 PC 直接跳转即可